### PR TITLE
add GitHub actions keepalive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,18 @@
+name: Keep workflows alive
+
+# Runs once every week, triggers GitHub API if time_elapsed days
+# have passed since last commit to keep actions active.
+on:
+  schedule:
+    - cron:  '0 0 * * 6'
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2
+        with:
+          time_elapsed: 40


### PR DESCRIPTION
This workflow runs weekly and only takes action if the last commit was over 40 days ago. In that case, GitHub API is triggered so workflows such as Chocomilk stay active.

This should hopefully get rid of the chore of re-enabling workflows manually from time to time, see e.g. #35 :wink: . 