### PR TITLE
configure keep alive workflow to keep chocomilk alive

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -15,4 +15,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gautamkrishnar/keepalive-workflow@v2
         with:
+          workflow_files: "chocomilk.yml"
           time_elapsed: 40


### PR DESCRIPTION
The keep-alive workflow explicitly needs to keep the chocomilk workflow alive, by default it only keeps itself active.

This was dfferent with "v1" which triggered dummy commits. "v2" of the keep-alive workflow uses the GitHub Actions API to keep the commit history clean, but if kept in a separate workflow file (which seems reasonable), it needs to iterate all workflows individually (in this case, chocomilk). 